### PR TITLE
ci(package): add git-cz for automatic generate commit messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ dev:
 dist: 
 	npm run dist
 
+commit:
+	npm run commit
+
 pub:
 	npm run pub
 

--- a/build/bin/new.js
+++ b/build/bin/new.js
@@ -45,12 +45,7 @@ fileSave(path.resolve(__dirname, '../../components.json'))
   .write(JSON.stringify(componentsList, null, '  '), 'utf-8')
   .end('\n')
 
-// packages入口index.js增加组件
-// const packagesEntryPath = path.join(__dirname, '../../packages/index.js')
-// const packagesEntryCont = `${fs.readFileSync(packagesEntryPath)}`;
-// console.log(packagesEntryCont, '🌹🌹🌹🌹🌹🌹🌹这里没想好怎么读写文件！🌹🌹🌹🌹🌹🌹🌹')
-// fileSave(path.resolve(__dirname, '../../packages/'))
-// .write()
+// packages入口index.js增加组件 - 根据build/build-entry.js自动生成
 
 // index.scss文件
 const scssEntryPath = path.join(__dirname, '../../styles/index.scss')

--- a/build/bin/verify-commit-msg.js
+++ b/build/bin/verify-commit-msg.js
@@ -1,0 +1,32 @@
+const chalk = require('chalk')
+const msgPath = process.env.GIT_PARAMS
+const msg = require('fs')
+  .readFileSync(msgPath, 'utf-8')
+  .trim()
+
+const commitRE = /^(revert: )?(feat|fix|polish|docs|style|refactor|perf|test|workflow|ci|chore|types|build)(\(.+\))?: .{1,50}/
+
+if (!commitRE.test(msg)) {
+  console.log()
+  console.error(
+    `  ${chalk.bgRed.white(' ERROR ')} ${chalk.red(
+      `commit信息的格式不正确.`
+    )}\n\n` +
+      chalk.red(
+        `  自动生成更改日志需要正确的commit信息格式. 比如下面这样:\n\n`
+      ) +
+      `    ${chalk.green(`feat(compiler): add 'comments' option`)}\n` +
+      `    ${chalk.green(
+        `fix(v-model): handle events on blur (close #28)`
+      )}\n\n` +
+      chalk.red(
+        `  可以查看 .github/COMMIT_CONVENTION.md 来获取更详细的说明信息.\n`
+      ) +
+      chalk.red(
+        `  你也可以使用 ${chalk.cyan(
+          `npm run commit`
+        )} 命令,以交互的形式自动生成commit提交信息.\n`
+      )
+  )
+  process.exit(1)
+}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "lint": "vue-cli-service lint",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
-    "pub": "sh build/git-release.sh && sh build/release.sh"
+    "pub": "sh build/git-release.sh && sh build/release.sh",
+    "commit": "git-cz"
   },
   "repository": {
     "type": "git",
@@ -53,6 +54,10 @@
     "babel-eslint": "^10.1.0",
     "babel-plugin-component": "^1.1.1",
     "chai": "^4.2.0",
+    "chalk": "^4.1.0",
+    "commitizen": "^4.2.2",
+    "conventional-changelog": "^3.1.24",
+    "cz-conventional-changelog": "^3.3.0",
     "eslint": "^6.8.0",
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-vue": "^7.1.0",
@@ -76,7 +81,8 @@
     "vitepress": "^0.7.1"
   },
   "gitHooks": {
-    "pre-commit": "lint-staged"
+    "pre-commit": "lint-staged",
+    "commit-msg": "node build/bin/verify-commit-msg.js"
   },
   "lint-staged": {
     "*.{js,jsx,vue}": [
@@ -93,6 +99,11 @@
       "stylelint --syntax=scss",
       "prettier --write"
     ]
+  },
+  "config": {
+    "commitizen": {
+      "path": "./node_modules/cz-conventional-changelog"
+    }
   },
   "engines": {
     "node": ">=8.9.1",


### PR DESCRIPTION
change git-cz, add verify-commit-msg, modified Makefile

BREAKING CHANGE: use git-cz instead of git-commit to generate a professional commit messages

re #42